### PR TITLE
OPS-3445 Update Helmfile-lint-action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM dtzar/helm-kubectl:3.9.4
+FROM dtzar/helm-kubectl:3.18.6
 
 ENV HELM_HOME=/root/.helm
-ENV HELMFILE_VERSION=1.1.3
+ENV HELMFILE_VERSION=1.1.6
 ENV SOPS_VERSION=v3.7.3
 
 RUN apk add --update-cache gnupg sed

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,8 @@ export REFERENCE=helmfile-ci-linting
 
 # Install helm plugins - cannot be done in the Dockerfile
 rm -rf  ~/.local/share/helm/plugins/
-helm plugin install https://github.com/jkroepke/helm-secrets --version 4.6.3 #use stable version
-helm plugin install https://github.com/databus23/helm-diff --version 3.11.0
+helm plugin install https://github.com/jkroepke/helm-secrets --version 4.6.1 #use stable version
+helm plugin install https://github.com/databus23/helm-diff --version 3.9.7
 helm plugin install https://github.com/chartmuseum/helm-push
 
 ###########################################################

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,8 @@ helm plugin install https://github.com/chartmuseum/helm-push
 ###########################################################
 
 # Import a (not-so-)secret key for SOPS to encrypt our dummy secret.yaml files
-gpg --import /sops_functional_tests_key.asc
+export GNUPGHOME=$(mktemp -d)
+gpg --batch --yes --import /sops_functional_tests_key.asc
 
 # This key is the fingerprint of one of the public keys contained in the file above
 export GPG_KEY_FINGERPRINT=FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,8 @@ export REFERENCE=helmfile-ci-linting
 
 # Install helm plugins - cannot be done in the Dockerfile
 rm -rf  ~/.local/share/helm/plugins/
-helm plugin install https://github.com/jkroepke/helm-secrets --version v3.15.0 #use stable version
-helm plugin install https://github.com/databus23/helm-diff
+helm plugin install https://github.com/jkroepke/helm-secrets --version 4.6.3 #use stable version
+helm plugin install https://github.com/databus23/helm-diff --version 3.11.0
 helm plugin install https://github.com/chartmuseum/helm-push
 
 ###########################################################

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,8 @@ export REFERENCE=helmfile-ci-linting
 
 # Install helm plugins - cannot be done in the Dockerfile
 rm -rf  ~/.local/share/helm/plugins/
-helm plugin install https://github.com/jkroepke/helm-secrets --version 4.6.1 #use stable version
-helm plugin install https://github.com/databus23/helm-diff --version 3.8.1
+helm plugin install https://github.com/jkroepke/helm-secrets --version 4.6.9 #use stable version
+helm plugin install https://github.com/databus23/helm-diff --version 3.12.5
 helm plugin install https://github.com/chartmuseum/helm-push
 
 ###########################################################

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ export REFERENCE=helmfile-ci-linting
 # Install helm plugins - cannot be done in the Dockerfile
 rm -rf  ~/.local/share/helm/plugins/
 helm plugin install https://github.com/jkroepke/helm-secrets --version 4.6.1 #use stable version
-helm plugin install https://github.com/databus23/helm-diff --version 3.9.7
+helm plugin install https://github.com/databus23/helm-diff --version 3.8.1
 helm plugin install https://github.com/chartmuseum/helm-push
 
 ###########################################################


### PR DESCRIPTION
[OPS-3445](https://welltravel.atlassian.net/browse/OPS-3445)
**Small Description:**
Currently `Helmfile-lint-action` is failing in `affiliates`. We didn't updated Helmfile-lint-action while updating helmfile.
- We have to update `helmfile-lint-action`

[OPS-3445]: https://welltravel.atlassian.net/browse/OPS-3445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ